### PR TITLE
✨ Implement Password Reset UI

### DIFF
--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -115,7 +115,43 @@ const authApi = {
    */
   logoutAll: async (): Promise<void> => {
     return await apiClient.post('/v1/auth/logout-all');
-  }
+  },
+
+  // authApi.ts 파일에 추가할 함수들입니다
+
+  /**
+   * 비밀번호 재설정 이메일 요청
+   * @param email 이메일
+   * @returns void
+   */
+  requestPasswordReset: async (email: string): Promise<void> => {
+    return await apiClient.post('/v1/auth/password-reset/request', { email });
+  },
+
+  /**
+   * 비밀번호 재설정 토큰 검증
+   * @param email 이메일
+   * @param token 토큰
+   * @returns 토큰 검증 결과
+   */
+  verifyPasswordResetToken: async (email: string, token: string): Promise<{ verified: boolean }> => {
+    return await apiClient.post('/v1/auth/password-reset/verify-token', { email, token });
+  },
+
+  /**
+   * 비밀번호 재설정
+   * @param email 이메일
+   * @param token 토큰
+   * @param newPassword 새 비밀번호
+   * @returns void
+   */
+  resetPassword: async (email: string, token: string, newPassword: string): Promise<void> => {
+    return await apiClient.post('/v1/auth/password-reset/reset', {
+      email,
+      token,
+      newPassword
+    });
+  },
 };
 
 export default authApi;

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Container,
+  Typography,
+  TextField,
+  Button,
+  Paper,
+  Alert,
+  Link,
+  CircularProgress
+} from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { authApi } from '@/api';
+
+const ForgotPassword: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!email) {
+      setError('이메일을 입력해주세요.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await authApi.requestPasswordReset(email);
+      setIsSuccess(true);
+    } catch (err: any) {
+      setError(err.message || '비밀번호 재설정 이메일 발송에 실패했습니다.');
+      console.error('Password reset request error:', err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box sx={{ mt: 5, mb: 5 }}>
+        <Paper elevation={3} sx={{ p: 4 }}>
+          <Typography variant="h5" component="h1" gutterBottom align="center">
+            비밀번호 찾기
+          </Typography>
+
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          )}
+
+          {isSuccess ? (
+            <Box>
+              <Alert severity="success" sx={{ mb: 2 }}>
+                비밀번호 재설정 링크가 이메일로 발송되었습니다. 이메일을 확인해주세요.
+              </Alert>
+              <Typography variant="body2" paragraph>
+                이메일에 포함된 링크를 통해 새 비밀번호를 설정하실 수 있습니다.
+                이메일이 보이지 않는 경우 스팸 폴더를 확인해주세요.
+              </Typography>
+              <Button
+                component={RouterLink}
+                to="/login"
+                variant="contained"
+                color="primary"
+                fullWidth
+                sx={{ mt: 2 }}
+              >
+                로그인 페이지로 돌아가기
+              </Button>
+            </Box>
+          ) : (
+            <Box component="form" onSubmit={handleSubmit}>
+              <Typography variant="body1" paragraph>
+                가입하신 이메일 주소를 입력하시면 비밀번호 재설정 링크를 보내드립니다.
+              </Typography>
+
+              <TextField
+                fullWidth
+                label="이메일"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                margin="normal"
+                required
+                autoFocus
+              />
+
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                color="primary"
+                sx={{ mt: 3, mb: 2 }}
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? (
+                  <CircularProgress size={24} color="inherit" />
+                ) : (
+                  '비밀번호 재설정 링크 받기'
+                )}
+              </Button>
+
+              <Box sx={{ mt: 2, textAlign: 'center' }}>
+                <Link component={RouterLink} to="/login" variant="body2">
+                  로그인으로 돌아가기
+                </Link>
+              </Box>
+            </Box>
+          )}
+        </Paper>
+      </Box>
+    </Container>
+  );
+};
+
+export default ForgotPassword;

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,0 +1,246 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Container,
+  Typography,
+  TextField,
+  Button,
+  Paper,
+  Alert,
+  Link,
+  CircularProgress,
+  InputAdornment,
+  IconButton
+} from '@mui/material';
+import { Link as RouterLink, useSearchParams } from 'react-router-dom';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import { authApi } from '@/api';
+
+const ResetPassword: React.FC = () => {
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(true);
+  const [isTokenValid, setIsTokenValid] = useState(false);
+
+  const [searchParams] = useSearchParams();
+
+  const token = searchParams.get('token');
+  const email = searchParams.get('email');
+
+  // 토큰 유효성 검증
+  useEffect(() => {
+    const verifyToken = async () => {
+      if (!token || !email) {
+        setError('유효하지 않은 링크입니다. 비밀번호 재설정을 다시 요청해주세요.');
+        setIsVerifying(false);
+        return;
+      }
+
+      try {
+        const response = await authApi.verifyPasswordResetToken(email, token);
+        setIsTokenValid(response.verified);
+        setIsVerifying(false);
+
+        if (!response.verified) {
+          setError('만료되거나 유효하지 않은 링크입니다. 비밀번호 재설정을 다시 요청해주세요.');
+        }
+      } catch (err: any) {
+        setError(err.message || '토큰 검증에 실패했습니다.');
+        setIsVerifying(false);
+        console.error('Token verification error:', err);
+      }
+    };
+
+    verifyToken();
+  }, [token, email]);
+
+  // 비밀번호 유효성 검증
+  const validatePassword = () => {
+    if (newPassword.length < 8) {
+      setError('비밀번호는 8자 이상이어야 합니다.');
+      return false;
+    }
+
+    if (!/(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*])/.test(newPassword)) {
+      setError('비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.');
+      return false;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError('비밀번호가 일치하지 않습니다.');
+      return false;
+    }
+
+    return true;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validatePassword() || !email || !token) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await authApi.resetPassword(email, token, newPassword);
+      setIsSuccess(true);
+    } catch (err: any) {
+      setError(err.message || '비밀번호 재설정에 실패했습니다.');
+      console.error('Password reset error:', err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // 로딩 화면
+  if (isVerifying) {
+    return (
+      <Container maxWidth="sm">
+        <Box sx={{ mt: 5, mb: 5, display: 'flex', justifyContent: 'center', alignItems: 'center', flexDirection: 'column' }}>
+          <CircularProgress />
+          <Typography variant="body1" sx={{ mt: 2 }}>
+            링크 확인 중...
+          </Typography>
+        </Box>
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth="sm">
+      <Box sx={{ mt: 5, mb: 5 }}>
+        <Paper elevation={3} sx={{ p: 4 }}>
+          <Typography variant="h5" component="h1" gutterBottom align="center">
+            비밀번호 재설정
+          </Typography>
+
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          )}
+
+          {!isTokenValid && !isSuccess ? (
+            <Box sx={{ textAlign: 'center' }}>
+              <Button
+                component={RouterLink}
+                to="/forgot-password"
+                variant="contained"
+                color="primary"
+                sx={{ mt: 2 }}
+              >
+                비밀번호 재설정 다시 요청하기
+              </Button>
+            </Box>
+          ) : isSuccess ? (
+            <Box>
+              <Alert severity="success" sx={{ mb: 2 }}>
+                비밀번호가 성공적으로 재설정되었습니다.
+              </Alert>
+              <Typography variant="body2" paragraph>
+                새 비밀번호로 로그인하실 수 있습니다.
+              </Typography>
+              <Button
+                component={RouterLink}
+                to="/login"
+                variant="contained"
+                color="primary"
+                fullWidth
+                sx={{ mt: 2 }}
+              >
+                로그인 페이지로 이동
+              </Button>
+            </Box>
+          ) : (
+            <Box component="form" onSubmit={handleSubmit}>
+              <Typography variant="body1" paragraph>
+                새로운 비밀번호를 입력해주세요.
+              </Typography>
+
+              <TextField
+                fullWidth
+                label="새 비밀번호"
+                type={showPassword ? 'text' : 'password'}
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                margin="normal"
+                required
+                autoFocus
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        onClick={() => setShowPassword(!showPassword)}
+                        edge="end"
+                      >
+                        {showPassword ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                }}
+              />
+
+              <TextField
+                fullWidth
+                label="새 비밀번호 확인"
+                type={showConfirmPassword ? 'text' : 'password'}
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                margin="normal"
+                required
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                        edge="end"
+                      >
+                        {showConfirmPassword ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                }}
+              />
+
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+                비밀번호는 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다.
+              </Typography>
+
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                color="primary"
+                sx={{ mt: 3, mb: 2 }}
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? (
+                  <CircularProgress size={24} color="inherit" />
+                ) : (
+                  '비밀번호 재설정'
+                )}
+              </Button>
+
+              <Box sx={{ mt: 2, textAlign: 'center' }}>
+                <Link component={RouterLink} to="/login" variant="body2">
+                  로그인으로 돌아가기
+                </Link>
+              </Box>
+            </Box>
+          )}
+        </Paper>
+      </Box>
+    </Container>
+  );
+};
+
+export default ResetPassword;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,6 +6,8 @@ import LoginPage from '@/pages/Login';
 import Register from '@/shared/components/auth/Register';
 import PrivateRoute from '@/shared/components/auth/PrivateRoute';
 import KakaoCallback from '@/pages/KakaoCallBack.tsx';
+import ForgotPassword from '@/pages/ForgotPassword';
+import ResetPassword from '@/pages/ResetPassword';
 
 export const Routes = () => {
   return (
@@ -15,6 +17,8 @@ export const Routes = () => {
         <Route index element={<HomePage />} /> {/* 홈 페이지는 공개 접근 가능 */}
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<Register />} />
+        <Route path="/forgot-password" element={<ForgotPassword />} />
+        <Route path="/reset-password" element={<ResetPassword />} />
 
         {/* 카카오 로그인 콜백 처리 라우트 추가 */}
         <Route path="/auth/kakao/callback" element={<KakaoCallback />} />


### PR DESCRIPTION
비밀번호 찾기 및 재설정 UI 구현

## 변경 사항
- 비밀번호 찾기 페이지 (`/forgot-password`) 개발 완료
- 비밀번호 재설정 페이지 (`/reset-password`) 구현
- 관련 API 호출 메서드 추가
- 라우트 및 로그인 페이지 연결 업데이트

## 주요 기능
- 이메일 입력 및 유효성 검증을 통한 재설정 링크 요청
- 이메일 링크에서 토큰과 이메일 파라미터 추출 및 검증
- 새 비밀번호 입력 및 복잡성 검증 (영문, 숫자, 특수문자 포함)
- 사용자 친화적인 오류 메시지 및 피드백 제공
- 처리 상태에 따른 로딩 인디케이터 및 결과 화면 표시

## 테스트 방법
1. 로그인 페이지에서 '비밀번호 찾기' 링크 클릭
2. 이메일 입력 및 요청 버튼 클릭
3. 이메일 수신 및 링크 클릭으로 재설정 페이지 접근
4. 새 비밀번호 설정 및 완료 화면 확인
5. 새 비밀번호로 로그인 테스트

## 주의 사항
- 백엔드 비밀번호 재설정 API가 구현되어 있어야 함
- 토큰 만료 상황의 적절한 사용자 안내 확인 필요
- 다양한 화면 크기에서의 반응형 디자인 테스트 필요
- 오류 상황 처리 및 사용자 피드백 검증 필요